### PR TITLE
Enable MacOS and Windows build, upgrade arrow to 0.16.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,31 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-10.14
+  strategy:
+    matrix:
+      osx_python3.7.____cpython:
+        CONFIG: osx_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_python3.8.____cpython:
+        CONFIG: osx_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+    maxParallel: 8
+  timeoutInMinutes: 360
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,112 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
+    matrix:
+      win_python3.7.____cpython:
+        CONFIG: win_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_python3.8.____cpython:
+        CONFIG: win_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+    maxParallel: 4
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+
+  steps:
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: true
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    
+
+    # Special cased version setting some more things!
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe (vs2008)
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+    - script: |
+        call activate base
+        validate_recipe_outputs "perspective-feedstock"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        call activate base
+        upload_package --validate --feedstock-name="perspective-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/.ci_support/osx_python3.8.____cpython.yaml
+++ b/.ci_support/osx_python3.8.____cpython.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -1,0 +1,18 @@
+boost:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+vc:
+- '14'

--- a/.ci_support/win_python3.8.____cpython.yaml
+++ b/.ci_support/win_python3.8.____cpython.yaml
@@ -1,0 +1,18 @@
+boost:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+vc:
+- '14'

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "perspective-feedstock"
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package --validate --feedstock-name="perspective-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/README.md
+++ b/README.md
@@ -43,22 +43,38 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/perspective-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpython" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9963&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/perspective-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9963&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/perspective-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9963&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/perspective-feedstock?branchName=master&jobName=win&configuration=win_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9963&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/perspective-feedstock?branchName=master&jobName=win&configuration=win_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
-    </td>
-  </tr>
-  <tr>
-    <td>Windows</td>
-    <td>
-      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
   <tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - pybind11
     - boost
     - numpy >=1.13.1
-    - pyarrow ==0.16.0
-    - arrow-cpp ==0.16.0
+    - pyarrow ==0.15.1
+    - arrow-cpp ==0.15.1
   run:
     - python
     - ipywidgets >=7.5.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
   sha256: 97406dc4b7920ab8b744324f67eff8b008bf2045ea53fe2714371dceba8a3a4b
 
 build:
-  number: 0
-  skip: true  # [py<37 or win or osx]
-  # skip: True  # [py<37 or (win and vc<14)]  # keep this for future reference
+  number: 1
+  # skip: true  # [py<37 or win or osx]
+  skip: True  # [py<37 or (win and vc<14)]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -26,8 +26,8 @@ requirements:
     - pybind11
     - boost
     - numpy >=1.13.1
-    - pyarrow ==0.15.1
-    - arrow-cpp ==0.15.1
+    - pyarrow ==0.16.0
+    - arrow-cpp ==0.16.0
   run:
     - python
     - ipywidgets >=7.5.1


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This re-enables the MacOS and Windows build after the changes made in 0.5.1 of Perspective, and bumps the version of PyArrow to 0.16.0.
<!--
Please add any other relevant info below:
-->
